### PR TITLE
Fix true/false questions

### DIFF
--- a/zanichelli.php
+++ b/zanichelli.php
@@ -52,7 +52,7 @@ class Zanichelli
         } else {
             $solutions = [];
             foreach ($options as $option) {
-                if ($option['correct']) $solutions[] = rtrim($option['text']);
+                if ($option['correct']) $solutions[] =  rtrim($option['text']??$option['question']);
             }
         }
 


### PR DESCRIPTION
Seems like ZTE changed "text" to "question" on some types of questions. This patch is tested and it seems to work.